### PR TITLE
fix: Ensure tense uniformity in log messages

### DIFF
--- a/unimol_tools/unimol_tools/data/conformer.py
+++ b/unimol_tools/unimol_tools/data/conformer.py
@@ -90,9 +90,9 @@ class ConformerGen(object):
         inputs = [item for item in tqdm(pool.imap(self.single_process, smiles_list))]
         pool.close()
         failed_cnt = np.mean([(item['src_coord']==0.0).all() for item in inputs])
-        logger.info('Succeed to generate conformers for {:.2f}% of molecules.'.format((1-failed_cnt)*100))
+        logger.info('Succeeded in generating conformers for {:.2f}% of molecules.'.format((1-failed_cnt)*100))
         failed_3d_cnt = np.mean([(item['src_coord'][:,2]==0.0).all() for item in inputs])
-        logger.info('Succeed to generate 3d conformers for {:.2f}% of molecules.'.format((1-failed_3d_cnt)*100))
+        logger.info('Succeeded in generating 3d conformers for {:.2f}% of molecules.'.format((1-failed_3d_cnt)*100))
         return inputs
 
 


### PR DESCRIPTION
Updated log messages to consistently use the past tense, ensuring grammatical correctness and improving readability. This change affects the messages related to conformer generation outcomes.