### PR TITLE
Initialize scaler when not using cuda

### DIFF
--- a/unimol_tools/unimol_tools/tasks/trainer.py
+++ b/unimol_tools/unimol_tools/tasks/trainer.py
@@ -96,6 +96,7 @@ class Trainer(object):
                 self.ddp = False
                 logger.info("Using single GPU.")
         else:
+            self.scaler = None
             self.device = torch.device("cpu")
             self.ddp = False
             logger.info("Using CPU.")


### PR DESCRIPTION
This fixes AttributeError when accessing uninitialized self.scaler in _compute_loss without cuda